### PR TITLE
Feature/spacio 21/get user info from acess token

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+[*.cs]
+dotnet_diagnostic.SA1600.severity = none
+
+
+# SA1101: Prefix local calls with this
+dotnet_diagnostic.SA1101.severity = none
+
+# SA1633: File should have header
+dotnet_diagnostic.SA1633.severity = none
+
+# SA1309: Field names should not begin with underscore
+dotnet_diagnostic.SA1309.severity = none
+
+# SA1010: Opening square brackets should be spaced correctly
+dotnet_diagnostic.SA1010.severity = none
+
+dotnet_diagnostic.SA1009.severity = none
+
+dotnet_diagnostic.SA1602.severity = none
+
+dotnet_diagnostic.SA1200.severity = none

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         run: dotnet restore
 
       - name: Check code format
-        run: dotnet format MediaService.sln --verify-no-changes
+        run: dotnet format UsersService.sln --verify-no-changes
     
       - name: Build
         run: dotnet build --no-restore --configuration Release

--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,4 @@ $RECYCLE.BIN/
 .DS_Store
 
 _NCrunch*
+Migrations

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ RUN dotnet publish -c Release -o /app/publish
 FROM base AS final
 WORKDIR /app
 COPY --from=build /app/publish .
-ENTRYPOINT ["dotnet", "EnvironmentsService.dll"]
+ENTRYPOINT ["dotnet", "UsersService.dll"]

--- a/UsersService.csproj
+++ b/UsersService.csproj
@@ -8,6 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Amazon.Extensions.CognitoAuthentication" Version="2.5.6" />
+    <PackageReference Include="AutoMapper" Version="12.0.1" />
+    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
     <PackageReference Include="AWSSDK.CognitoIdentityProvider" Version="3.7.407.32" />
     <PackageReference Include="DotNetEnv" Version="3.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.3" />
@@ -18,6 +20,10 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.1" />
   </ItemGroup>
 

--- a/src/Application/DTOs/LoggedUserDTO.cs
+++ b/src/Application/DTOs/LoggedUserDTO.cs
@@ -1,0 +1,26 @@
+namespace UsersService.Src.Application.DTOs;
+
+public class LoggedUserDTO
+{
+    public Guid PublicId { get; set; }
+
+    public string Name { get; set; } = string.Empty;
+
+    public string Email { get; set; } = string.Empty;
+
+    public string Phone { get; set; } = string.Empty;
+
+    public bool VerifiedEmail { get; set; }
+
+    public bool VerifiedPhone { get; set; }
+
+    required public string Role { get; set; }
+
+    public string? PhotoFileId { get; set; }
+
+    public string? PhotoFileName { get; set; }
+
+    public string? PhotoFileUrl { get; set; }
+
+    public bool? Verified { get; set; }
+}

--- a/src/Application/DTOs/PublicUserDTO.cs
+++ b/src/Application/DTOs/PublicUserDTO.cs
@@ -1,0 +1,22 @@
+namespace UsersService.Src.Application.DTOs;
+
+public class UserDTO
+{
+    public Guid PublicId { get; set; }
+
+    public string Name { get; set; } = string.Empty;
+
+    public string Email { get; set; } = string.Empty;
+
+    public string Phone { get; set; } = string.Empty;
+
+    public bool VerifiedEmail { get; set; }
+
+    public bool VerifiedPhone { get; set; }
+
+    required public string Role { get; set; }
+
+    public string? PhotoFileUrl { get; set; }
+
+    public bool? Verified { get; set; }
+}

--- a/src/Application/Interfaces/IUserService.cs
+++ b/src/Application/Interfaces/IUserService.cs
@@ -1,0 +1,9 @@
+using System;
+using UsersService.Src.Application.DTOs;
+
+namespace UsersService.Src.Application.Interfaces;
+
+public interface IUserService
+{
+    Task<UserDTO?> GetByPublicIdAsync(Guid publicId);
+}

--- a/src/Application/Mapping/UserProfile.cs
+++ b/src/Application/Mapping/UserProfile.cs
@@ -1,0 +1,28 @@
+namespace UsersService.Src.Application.Mapping;
+
+using AutoMapper;
+using UsersService.Src.Application.DTOs;
+using UsersService.Src.Domain.Entities;
+using UsersService.Src.Domain.Enums;
+
+public class UserProfile : Profile
+{
+    public UserProfile()
+    {
+        CreateMap<User, UserDTO>()
+            .ForMember(dest => dest.Role, opt => opt.MapFrom(src => src.Role.ToString()))
+            .ForMember(dest => dest.PhotoFileUrl, opt => opt.MapFrom(src =>
+                !string.IsNullOrEmpty(src.PhotoFileId) ? $"/media/{src.PhotoFileId}" : null));
+
+        CreateMap<User, LoggedUserDTO>()
+            .ForMember(dest => dest.Role, opt => opt.MapFrom(src => src.Role.ToString()))
+            .ForMember(dest => dest.PhotoFileUrl, opt => opt.MapFrom(src =>
+                !string.IsNullOrEmpty(src.PhotoFileId) ? $"/media/{src.PhotoFileId}" : null));
+
+        CreateMap<UserDTO, User>()
+            .ForMember(dest => dest.Role, opt => opt.MapFrom(src => Enum.Parse<UserRole>(src.Role)));
+
+        CreateMap<LoggedUserDTO, User>()
+            .ForMember(dest => dest.Role, opt => opt.MapFrom(src => Enum.Parse<UserRole>(src.Role)));
+    }
+}

--- a/src/Application/Services/UserService.cs
+++ b/src/Application/Services/UserService.cs
@@ -1,0 +1,25 @@
+using System;
+using AutoMapper;
+using UsersService.Src.Application.DTOs;
+using UsersService.Src.Application.Interfaces;
+using UsersService.Src.Domain.Interfaces;
+
+namespace UsersService.src.Application.Services;
+
+public class UserService : IUserService
+{
+    private readonly IUserRepository _userRepository;
+    private readonly IMapper _mapper;
+
+    public UserService(IUserRepository userRepository, IMapper mapper)
+    {
+        _userRepository = userRepository;
+        _mapper = mapper;
+    }
+
+    public async Task<UserDTO?> GetByPublicIdAsync(Guid publicId)
+    {
+        var user = await _userRepository.GetByPublicIdAsync(publicId);
+        return user == null ? null : _mapper.Map<UserDTO>(user);
+    }
+}

--- a/src/Domain/Entities/User.cs
+++ b/src/Domain/Entities/User.cs
@@ -1,0 +1,30 @@
+using UsersService.Src.Domain.Enums;
+
+namespace UsersService.Src.Domain.Entities;
+
+public class User
+{
+    public Guid Id { get; set; }
+
+    public Guid PublicId { get; set; }
+
+    public string Name { get; set; } = string.Empty;
+
+    public string Email { get; set; } = string.Empty;
+
+    public string Phone { get; set; } = string.Empty;
+
+    public bool VerifiedEmail { get; set; }
+
+    public bool VerifiedPhone { get; set; }
+
+    public UserRole Role { get; set; }
+
+    public string? PhotoFileId { get; set; }
+
+    public string? PhotoFileName { get; set; }
+
+    public string? PhotoFileUrl { get; set; }
+
+    public bool? Verified { get; set; }
+}

--- a/src/Domain/Enums/UserRole.cs
+++ b/src/Domain/Enums/UserRole.cs
@@ -1,0 +1,8 @@
+namespace UsersService.Src.Domain.Enums;
+
+public enum UserRole
+{
+    User,
+    Owner,
+    Admin,
+}

--- a/src/Domain/Interfaces/IUserRepository.cs
+++ b/src/Domain/Interfaces/IUserRepository.cs
@@ -1,0 +1,8 @@
+using UsersService.Src.Domain.Entities;
+
+namespace UsersService.Src.Domain.Interfaces;
+
+public interface IUserRepository
+{
+    Task<User?> GetByPublicIdAsync(Guid publicId);
+}

--- a/src/Infraestructure/Data/AppDBContext.cs
+++ b/src/Infraestructure/Data/AppDBContext.cs
@@ -1,0 +1,16 @@
+using Microsoft.EntityFrameworkCore;
+using UsersService.Src.Domain.Entities;
+
+namespace UsersService.Src.Infraestructure.Data;
+
+public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(options)
+{
+    public DbSet<User> Users { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<User>()
+            .Property(u => u.Role)
+            .HasConversion<string>();
+    }
+}

--- a/src/Infraestructure/Repositories/UserRepository.cs
+++ b/src/Infraestructure/Repositories/UserRepository.cs
@@ -1,0 +1,22 @@
+using Microsoft.EntityFrameworkCore;
+using UsersService.Src.Domain.Entities;
+using UsersService.Src.Domain.Interfaces;
+using UsersService.Src.Infraestructure.Data;
+
+namespace UsersService.Src.Infraestructure.Repositories;
+
+public class UserRepository : IUserRepository
+{
+    private readonly AppDbContext _context;
+
+    public UserRepository(AppDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<User?> GetByPublicIdAsync(Guid publicId)
+    {
+        return await _context.Users
+            .FirstOrDefaultAsync(u => u.PublicId == publicId);
+    }
+}

--- a/src/WebApi/Controllers/UserController.cs
+++ b/src/WebApi/Controllers/UserController.cs
@@ -1,0 +1,29 @@
+namespace UsersService.src.WebApi.Controllers;
+
+using Microsoft.AspNetCore.Mvc;
+using UsersService.Src.Application.DTOs;
+using UsersService.Src.Application.Interfaces;
+
+[ApiController]
+[Route("api/[controller]")]
+public class UsersController : ControllerBase
+{
+    private readonly IUserService _userService;
+
+    public UsersController(IUserService userService)
+    {
+        _userService = userService;
+    }
+
+    [HttpGet("{publicId}")]
+    public async Task<ActionResult<UserDTO>> GetUserByPublicId(Guid publicId)
+    {
+        var user = await _userService.GetByPublicIdAsync(publicId);
+        if (user == null)
+        {
+            return NotFound();
+        }
+
+        return Ok(user);
+    }
+}

--- a/src/WebApi/Program.cs
+++ b/src/WebApi/Program.cs
@@ -1,6 +1,10 @@
 using Microsoft.EntityFrameworkCore;
+using UsersService.Src.Application.Interfaces;
 using UsersService.Src.Application.Mapping;
+using UsersService.src.Application.Services;
+using UsersService.Src.Domain.Interfaces;
 using UsersService.Src.Infraestructure.Data;
+using UsersService.Src.Infraestructure.Repositories;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -12,6 +16,8 @@ builder.Services.AddControllers();
 
 builder.Services.AddDbContext<AppDbContext>(options =>
     options.UseNpgsql(builder.Configuration.GetConnectionString("DefaultConnection")));
+builder.Services.AddScoped<IUserRepository, UserRepository>();
+builder.Services.AddScoped<IUserService, UserService>();
 
 builder.Services.AddCors(options =>
 {

--- a/src/WebApi/Program.cs
+++ b/src/WebApi/Program.cs
@@ -1,3 +1,7 @@
+using Microsoft.EntityFrameworkCore;
+using UsersService.Src.Application.Mapping;
+using UsersService.Src.Infraestructure.Data;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
@@ -5,6 +9,9 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddOpenApi();
 builder.Services.AddSwaggerGen();
 builder.Services.AddControllers();
+
+builder.Services.AddDbContext<AppDbContext>(options =>
+    options.UseNpgsql(builder.Configuration.GetConnectionString("DefaultConnection")));
 
 builder.Services.AddCors(options =>
 {
@@ -15,6 +22,8 @@ builder.Services.AddCors(options =>
               .AllowAnyHeader();
     });
 });
+
+builder.Services.AddAutoMapper(typeof(UserProfile));
 
 var app = builder.Build();
 app.MapControllers();


### PR DESCRIPTION
### **What I Did**

- Implemented a new endpoint: `GET /api/users/{publicId}` to retrieve user information by their public identifier.
- Followed **Clean Architecture** principles to organize code by layers: `Core`, `Application`, `Infrastructure`, and `WebAPI`.
- Added mappings via **AutoMapper** to return a properly formatted `UserDTO`.

---

### **Why I Did It**

- The application requires a secure and consistent way to expose user data to external services and clients without exposing internal `User.Id`.
- `publicId` (GUID) is a safer and more stable identifier for APIs.
- Needed to follow best practices by keeping the logic testable, extendable, and layered.

---

### **How I Did It**

- **Core Layer:**
  - Defined `IUserRepository` and `IUserService` interfaces for abstraction.
- **Infrastructure Layer:**
  - Created `UserRepository` with an `EF Core` query to find users by `publicId`.
- **Application Layer:**
  - Built `UserService` to coordinate retrieval and DTO transformation using `AutoMapper`.
- **WebAPI Layer:**
  - Added a new route in `UsersController` to expose the functionality as a REST endpoint.