### PR TITLE
Feature/spacio 57/log in generate access token

### DIFF
--- a/appsettings.json
+++ b/appsettings.json
@@ -12,7 +12,9 @@
   "AWS": {
     "Cognito": {
       "UserPoolId": "us-east-2_txErenTKJ",
-      "ClientId": "57miertjsvu0lrv70p76cveg6h"
+      "ClientId": "2kdp78isnabghg1g99ai9og3s6",
+      "ClientSecret": "2tmb15ovoh0ndph6qfo77rl3qmeei9vnnt8djrqef8duif7eaqk",
+      "Region": "us-east-2"
     }
   }
 }

--- a/src/Application/Commands/Concretes/GetLoggedUserCommand.cs
+++ b/src/Application/Commands/Concretes/GetLoggedUserCommand.cs
@@ -1,0 +1,29 @@
+namespace UsersService.Src.Application.Commands.Concretes;
+
+using Amazon.CognitoIdentityProvider;
+using Amazon.CognitoIdentityProvider.Model;
+using UsersService.Src.Application.DTOs;
+using UsersService.Src.Domain.Interfaces;
+using AutoMapper;
+using UsersService.Src.Application.Commands.Interfaces;
+
+public class GetLoggedUserCommand(AmazonCognitoIdentityProviderClient provider, IUserRepository repo, IMapper mapper) : ICommand<string, LoggedUserDTO?>
+{
+    private readonly AmazonCognitoIdentityProviderClient _provider = provider;
+    private readonly IUserRepository _userRepository = repo;
+    private readonly IMapper _mapper = mapper;
+
+    public async Task<LoggedUserDTO?> ExecuteAsync(string accessToken)
+    {
+        var response = await _provider.GetUserAsync(new GetUserRequest { AccessToken = accessToken });
+        var sub = response.UserAttributes.FirstOrDefault(a => a.Name == "sub")?.Value;
+
+        if (string.IsNullOrEmpty(sub))
+        {
+            return null;
+        }
+
+        var user = await _userRepository.GetByIdAsync(Guid.Parse(sub));
+        return user == null ? null : _mapper.Map<LoggedUserDTO>(user);
+    }
+}

--- a/src/Application/Commands/Concretes/GetUserByPublicIdCommand.cs
+++ b/src/Application/Commands/Concretes/GetUserByPublicIdCommand.cs
@@ -1,0 +1,18 @@
+namespace UsersService.Src.Application.Commands.Concretes;
+
+using UsersService.Src.Application.DTOs;
+using UsersService.Src.Domain.Interfaces;
+using AutoMapper;
+using UsersService.Src.Application.Commands.Interfaces;
+
+public class GetUserByPublicIdCommand(IUserRepository userRepository, IMapper mapper) : ICommand<Guid, UserDTO?>
+{
+    private readonly IUserRepository _userRepository = userRepository;
+    private readonly IMapper _mapper = mapper;
+
+    public async Task<UserDTO?> ExecuteAsync(Guid publicId)
+    {
+        var user = await _userRepository.GetByPublicIdAsync(publicId);
+        return user == null ? null : _mapper.Map<UserDTO>(user);
+    }
+}

--- a/src/Application/Commands/Concretes/LogInUserCommand.cs
+++ b/src/Application/Commands/Concretes/LogInUserCommand.cs
@@ -1,0 +1,39 @@
+namespace UsersService.Src.Application.Commands.Concretes;
+
+using Amazon.CognitoIdentityProvider;
+using Amazon.Extensions.CognitoAuthentication;
+using UsersService.Src.Application.DTOs;
+using UsersService.Src.Domain.Interfaces;
+using AutoMapper;
+using UsersService.Src.Application.Commands.Interfaces;
+
+public class LoginUserCommand(AmazonCognitoIdentityProviderClient provider, CognitoUserPool userPool, IUserRepository repo, IMapper mapper) : ICommand<(string Email, string Password), LoggedUserDTO?>
+{
+    private readonly AmazonCognitoIdentityProviderClient _provider = provider;
+    private readonly CognitoUserPool _userPool = userPool;
+    private readonly IUserRepository _userRepository = repo;
+    private readonly IMapper _mapper = mapper;
+
+    public async Task<LoggedUserDTO?> ExecuteAsync((string Email, string Password) input)
+    {
+        var user = new CognitoUser(input.Email, _userPool.ClientID, _userPool, _provider);
+        var authRequest = new InitiateSrpAuthRequest { Password = input.Password };
+
+        var authResponse = await user.StartWithSrpAuthAsync(authRequest);
+        if (authResponse.AuthenticationResult == null)
+        {
+            return null;
+        }
+
+        var appUser = await _userRepository.GetByIdAsync(Guid.Parse(user.Username));
+        if (appUser == null)
+        {
+            return null;
+        }
+
+        var dto = _mapper.Map<LoggedUserDTO>(appUser);
+        dto.AccessToken = authResponse.AuthenticationResult.AccessToken;
+        dto.RefreshToken = authResponse.AuthenticationResult.RefreshToken;
+        return dto;
+    }
+}

--- a/src/Application/Commands/Concretes/RefreshAccessTokenCommand.cs
+++ b/src/Application/Commands/Concretes/RefreshAccessTokenCommand.cs
@@ -1,0 +1,28 @@
+namespace UsersService.Src.Application.Commands.Concretes;
+
+using Amazon.CognitoIdentityProvider;
+using Amazon.CognitoIdentityProvider.Model;
+using Amazon.Extensions.CognitoAuthentication;
+using UsersService.Src.Application.Commands.Interfaces;
+
+public class RefreshAccessTokenCommand(AmazonCognitoIdentityProviderClient provider, CognitoUserPool userPool) : ICommand<string, string?>
+{
+    private readonly AmazonCognitoIdentityProviderClient _provider = provider;
+    private readonly CognitoUserPool _userPool = userPool;
+
+    public async Task<string?> ExecuteAsync(string refreshToken)
+    {
+        var request = new InitiateAuthRequest
+        {
+            AuthFlow = AuthFlowType.REFRESH_TOKEN_AUTH,
+            ClientId = _userPool.ClientID,
+            AuthParameters = new Dictionary<string, string>
+            {
+                { "REFRESH_TOKEN", refreshToken },
+            },
+        };
+
+        var result = await _provider.InitiateAuthAsync(request);
+        return result.AuthenticationResult?.AccessToken;
+    }
+}

--- a/src/Application/Commands/Concretes/ValidateAccessTokenCommand.cs
+++ b/src/Application/Commands/Concretes/ValidateAccessTokenCommand.cs
@@ -1,0 +1,21 @@
+namespace UsersService.Src.Application.Commands.Concretes;
+
+using System.IdentityModel.Tokens.Jwt;
+using UsersService.Src.Application.Commands.Interfaces;
+
+public class ValidateAccessTokenCommand : ICommand<string, bool>
+{
+    public Task<bool> ExecuteAsync(string accessToken)
+    {
+        try
+        {
+            var handler = new JwtSecurityTokenHandler();
+            var token = handler.ReadJwtToken(accessToken);
+            return Task.FromResult(token.ValidTo > DateTime.UtcNow);
+        }
+        catch
+        {
+            return Task.FromResult(false);
+        }
+    }
+}

--- a/src/Application/Commands/Interfaces/ICommand.cs
+++ b/src/Application/Commands/Interfaces/ICommand.cs
@@ -1,0 +1,6 @@
+namespace UsersService.Src.Application.Commands.Interfaces;
+
+public interface ICommand<TInput, TOutput>
+{
+    Task<TOutput> ExecuteAsync(TInput input);
+}

--- a/src/Application/DTOs/LogInRequest.cs
+++ b/src/Application/DTOs/LogInRequest.cs
@@ -1,0 +1,8 @@
+namespace UsersService.Src.Application.DTOs;
+
+public class LoginRequest
+{
+    public string Email { get; set; } = string.Empty;
+
+    public string Password { get; set; } = string.Empty;
+}

--- a/src/Application/DTOs/LoggedUserDTO.cs
+++ b/src/Application/DTOs/LoggedUserDTO.cs
@@ -23,4 +23,8 @@ public class LoggedUserDTO
     public string? PhotoFileUrl { get; set; }
 
     public bool? Verified { get; set; }
+
+    public string AccessToken { get; set; } = string.Empty;
+
+    public string RefreshToken { get; set; } = string.Empty;
 }

--- a/src/Application/DTOs/RefreshTokenRequest.cs
+++ b/src/Application/DTOs/RefreshTokenRequest.cs
@@ -1,0 +1,6 @@
+namespace UsersService.Src.Application.DTOs;
+
+public class RefreshTokenRequest
+{
+    public string RefreshToken { get; set; } = string.Empty;
+}

--- a/src/Application/Interfaces/IUserService.cs
+++ b/src/Application/Interfaces/IUserService.cs
@@ -8,4 +8,10 @@ public interface IUserService
     Task<UserDTO?> GetByPublicIdAsync(Guid publicId);
 
     Task<LoggedUserDTO?> LoginAsync(string email, string password);
+
+    Task<LoggedUserDTO?> GetUserFromAccessTokenAsync(string accessToken);
+
+    Task<string?> RefreshAccessTokenAsync(string refreshToken);
+
+    Task<bool> IsAccessTokenValidAsync(string accessToken);
 }

--- a/src/Application/Interfaces/IUserService.cs
+++ b/src/Application/Interfaces/IUserService.cs
@@ -6,4 +6,6 @@ namespace UsersService.Src.Application.Interfaces;
 public interface IUserService
 {
     Task<UserDTO?> GetByPublicIdAsync(Guid publicId);
+
+    Task<LoggedUserDTO?> LoginAsync(string email, string password);
 }

--- a/src/Application/Services/UserService.cs
+++ b/src/Application/Services/UserService.cs
@@ -1,146 +1,34 @@
-using System.IdentityModel.Tokens.Jwt;
-using System.Security.Cryptography;
-using System.Text;
-using Amazon.CognitoIdentityProvider;
-using Amazon.CognitoIdentityProvider.Model;
-using Amazon.Extensions.CognitoAuthentication;
-using AutoMapper;
+using UsersService.Src.Application.Commands.Interfaces;
 using UsersService.Src.Application.DTOs;
 using UsersService.Src.Application.Interfaces;
-using UsersService.Src.Domain.Interfaces;
 
 namespace UsersService.src.Application.Services;
 
-public class UserService : IUserService
+public class UserService(
+    ICommand<(string, string), LoggedUserDTO?> loginUserCommand,
+    ICommand<string, LoggedUserDTO?> getLoggedUserCommand,
+    ICommand<Guid, UserDTO?> getUserByPublicIdCommand,
+    ICommand<string, string?> refreshTokenCommand,
+    ICommand<string, bool> validateAccessTokenCommand) : IUserService
 {
-    private readonly IUserRepository _userRepository;
-    private readonly IMapper _mapper;
-    private readonly AmazonCognitoIdentityProviderClient _provider;
-    private readonly CognitoUserPool _userPool;
+    private readonly ICommand<(string, string), LoggedUserDTO?> _loginUserCommand = loginUserCommand;
+    private readonly ICommand<string, LoggedUserDTO?> _getLoggedUserCommand = getLoggedUserCommand;
+    private readonly ICommand<Guid, UserDTO?> _getUserByPublicIdCommand = getUserByPublicIdCommand;
+    private readonly ICommand<string, string?> _refreshTokenCommand = refreshTokenCommand;
+    private readonly ICommand<string, bool> _validateAccessTokenCommand = validateAccessTokenCommand;
 
-    public UserService(IUserRepository userRepository, IMapper mapper, IConfiguration config)
-    {
-        _userRepository = userRepository;
-        _mapper = mapper;
-        _provider = new AmazonCognitoIdentityProviderClient(Amazon.RegionEndpoint.USEast2);
-        _userPool = new CognitoUserPool(
-            config["AWS:Cognito:UserPoolId"],
-            config["AWS:Cognito:ClientId"],
-            _provider);
-    }
+    public Task<UserDTO?> GetByPublicIdAsync(Guid publicId) =>
+        _getUserByPublicIdCommand.ExecuteAsync(publicId);
 
-    public async Task<UserDTO?> GetByPublicIdAsync(Guid publicId)
-    {
-        var user = await _userRepository.GetByPublicIdAsync(publicId);
-        return user == null ? null : _mapper.Map<UserDTO>(user);
-    }
+    public Task<LoggedUserDTO?> LoginAsync(string email, string password) =>
+        _loginUserCommand.ExecuteAsync((email, password));
 
-    public async Task<LoggedUserDTO?> LoginAsync(string email, string password)
-    {
-        var user = new CognitoUser(email, _userPool.ClientID, _userPool, _provider);
+    public Task<LoggedUserDTO?> GetUserFromAccessTokenAsync(string accessToken) =>
+        _getLoggedUserCommand.ExecuteAsync(accessToken);
 
-        var authRequest = new InitiateSrpAuthRequest { Password = password };
+    public Task<string?> RefreshAccessTokenAsync(string refreshToken) =>
+        _refreshTokenCommand.ExecuteAsync(refreshToken);
 
-        try
-        {
-            var authResponse = await user.StartWithSrpAuthAsync(authRequest).ConfigureAwait(false);
-            Console.WriteLine(authResponse.AuthenticationResult);
-            if (authResponse.AuthenticationResult == null)
-            {
-                return null;
-            }
-
-            var cognitoSub = user.UserID;
-            var name = user.Username;
-
-            var appUser = await _userRepository.GetByIdAsync(Guid.Parse(name));
-
-            if (appUser != null)
-            {
-                var dto = _mapper.Map<LoggedUserDTO>(appUser);
-                dto.AccessToken = authResponse.AuthenticationResult.AccessToken;
-                dto.RefreshToken = authResponse.AuthenticationResult.RefreshToken;
-                return dto;
-            }
-
-            return null;
-        }
-        catch
-        {
-            return null;
-        }
-    }
-
-    public async Task<LoggedUserDTO?> GetUserFromAccessTokenAsync(string accessToken)
-    {
-        try
-        {
-            var request = new Amazon.CognitoIdentityProvider.Model.GetUserRequest
-            {
-                AccessToken = accessToken,
-            };
-
-            var response = await _provider.GetUserAsync(request);
-            var sub = response.UserAttributes.FirstOrDefault(a => a.Name == "sub")?.Value;
-            Console.WriteLine(response);
-
-            if (string.IsNullOrEmpty(sub))
-            {
-                return null;
-            }
-
-            var user = await _userRepository.GetByIdAsync(Guid.Parse(sub));
-            return user == null ? null : _mapper.Map<LoggedUserDTO>(user);
-        }
-        catch
-        {
-            return null;
-        }
-    }
-
-    public async Task<string?> RefreshAccessTokenAsync(string refreshToken)
-    {
-        var request = new InitiateAuthRequest
-        {
-            AuthFlow = AuthFlowType.REFRESH_TOKEN_AUTH,
-            ClientId = _userPool.ClientID,
-            AuthParameters = new Dictionary<string, string>
-            {
-                { "REFRESH_TOKEN", refreshToken },
-            },
-        };
-
-        try
-        {
-            var result = await _provider.InitiateAuthAsync(request);
-            return result.AuthenticationResult?.AccessToken;
-        }
-        catch
-        {
-            return null;
-        }
-    }
-
-    public Task<bool> IsAccessTokenValidAsync(string accessToken)
-    {
-        try
-        {
-            var handler = new JwtSecurityTokenHandler();
-            var token = handler.ReadJwtToken(accessToken);
-            var exp = token.ValidTo;
-            return Task.FromResult(exp > DateTime.UtcNow);
-        }
-        catch
-        {
-            return Task.FromResult(false);
-        }
-    }
-
-    private string GenerateSecretHash(string username, string clientId, string clientSecret)
-    {
-        var key = Encoding.UTF8.GetBytes(clientSecret);
-        var message = Encoding.UTF8.GetBytes(username + clientId);
-        using var hmac = new HMACSHA256(key);
-        return Convert.ToBase64String(hmac.ComputeHash(message));
-    }
+    public Task<bool> IsAccessTokenValidAsync(string accessToken) =>
+        _validateAccessTokenCommand.ExecuteAsync(accessToken);
 }

--- a/src/Application/Services/UserService.cs
+++ b/src/Application/Services/UserService.cs
@@ -1,4 +1,5 @@
-using System;
+using Amazon.CognitoIdentityProvider;
+using Amazon.Extensions.CognitoAuthentication;
 using AutoMapper;
 using UsersService.Src.Application.DTOs;
 using UsersService.Src.Application.Interfaces;
@@ -10,16 +11,59 @@ public class UserService : IUserService
 {
     private readonly IUserRepository _userRepository;
     private readonly IMapper _mapper;
+    private readonly AmazonCognitoIdentityProviderClient _provider;
+    private readonly CognitoUserPool _userPool;
 
-    public UserService(IUserRepository userRepository, IMapper mapper)
+    public UserService(IUserRepository userRepository, IMapper mapper, IConfiguration config)
     {
         _userRepository = userRepository;
         _mapper = mapper;
+        _provider = new AmazonCognitoIdentityProviderClient(Amazon.RegionEndpoint.USEast2);
+        _userPool = new CognitoUserPool(
+            config["AWS:Cognito:UserPoolId"],
+            config["AWS:Cognito:ClientId"],
+            _provider);
     }
 
     public async Task<UserDTO?> GetByPublicIdAsync(Guid publicId)
     {
         var user = await _userRepository.GetByPublicIdAsync(publicId);
         return user == null ? null : _mapper.Map<UserDTO>(user);
+    }
+
+    public async Task<LoggedUserDTO?> LoginAsync(string email, string password)
+    {
+        var user = new CognitoUser(email, _userPool.ClientID, _userPool, _provider);
+
+        var authRequest = new InitiateSrpAuthRequest { Password = password };
+
+        try
+        {
+            var authResponse = await user.StartWithSrpAuthAsync(authRequest).ConfigureAwait(false);
+            Console.WriteLine(authResponse.AuthenticationResult);
+            if (authResponse.AuthenticationResult == null)
+            {
+                return null;
+            }
+
+            var cognitoSub = user.UserID;
+            var name = user.Username;
+
+            var appUser = await _userRepository.GetByIdAsync(Guid.Parse(name));
+
+            if (appUser != null)
+            {
+                var dto = _mapper.Map<LoggedUserDTO>(appUser);
+                dto.AccessToken = authResponse.AuthenticationResult.AccessToken;
+                dto.RefreshToken = authResponse.AuthenticationResult.RefreshToken;
+                return dto;
+            }
+
+            return null;
+        }
+        catch
+        {
+            return null;
+        }
     }
 }

--- a/src/Domain/Interfaces/IUserRepository.cs
+++ b/src/Domain/Interfaces/IUserRepository.cs
@@ -5,4 +5,6 @@ namespace UsersService.Src.Domain.Interfaces;
 public interface IUserRepository
 {
     Task<User?> GetByPublicIdAsync(Guid publicId);
+
+    Task<User?> GetByIdAsync(Guid subId);
 }

--- a/src/Infraestructure/Repositories/UserRepository.cs
+++ b/src/Infraestructure/Repositories/UserRepository.cs
@@ -5,18 +5,18 @@ using UsersService.Src.Infraestructure.Data;
 
 namespace UsersService.Src.Infraestructure.Repositories;
 
-public class UserRepository : IUserRepository
+public class UserRepository(AppDbContext context) : IUserRepository
 {
-    private readonly AppDbContext _context;
-
-    public UserRepository(AppDbContext context)
-    {
-        _context = context;
-    }
+    private readonly AppDbContext _context = context;
 
     public async Task<User?> GetByPublicIdAsync(Guid publicId)
     {
         return await _context.Users
             .FirstOrDefaultAsync(u => u.PublicId == publicId);
+    }
+
+    public async Task<User?> GetByIdAsync(Guid id)
+    {
+        return await _context.Users.FirstOrDefaultAsync(u => u.Id == id);
     }
 }

--- a/src/WebApi/Controllers/UserController.cs
+++ b/src/WebApi/Controllers/UserController.cs
@@ -1,6 +1,5 @@
 namespace UsersService.src.WebApi.Controllers;
 
-using Microsoft.AspNetCore.Identity.Data;
 using Microsoft.AspNetCore.Mvc;
 using UsersService.Src.Application.DTOs;
 using UsersService.Src.Application.Interfaces;
@@ -33,5 +32,28 @@ public class UsersController(IUserService userService) : ControllerBase
         }
 
         return Ok(user);
+    }
+
+    [HttpGet("me")]
+    public async Task<ActionResult<LoggedUserDTO>> GetCurrentUser()
+    {
+        var accessToken = Request.Headers.Authorization.ToString().Replace("Bearer ", string.Empty);
+        var user = await _userService.GetUserFromAccessTokenAsync(accessToken);
+        return user == null ? Unauthorized() : Ok(user);
+    }
+
+    [HttpPost("refresh")]
+    public async Task<ActionResult<string>> RefreshAccessToken([FromBody] RefreshTokenRequest request)
+    {
+        var newToken = await _userService.RefreshAccessTokenAsync(request.RefreshToken);
+        return string.IsNullOrEmpty(newToken) ? Unauthorized() : Ok(newToken);
+    }
+
+    [HttpGet("verify-token")]
+    public async Task<ActionResult<bool>> VerifyAccessToken()
+    {
+        var accessToken = Request.Headers.Authorization.ToString().Replace("Bearer ", string.Empty);
+        var isValid = await _userService.IsAccessTokenValidAsync(accessToken);
+        return Ok(isValid);
     }
 }

--- a/src/WebApi/Controllers/UserController.cs
+++ b/src/WebApi/Controllers/UserController.cs
@@ -1,19 +1,15 @@
 namespace UsersService.src.WebApi.Controllers;
 
+using Microsoft.AspNetCore.Identity.Data;
 using Microsoft.AspNetCore.Mvc;
 using UsersService.Src.Application.DTOs;
 using UsersService.Src.Application.Interfaces;
 
 [ApiController]
 [Route("api/[controller]")]
-public class UsersController : ControllerBase
+public class UsersController(IUserService userService) : ControllerBase
 {
-    private readonly IUserService _userService;
-
-    public UsersController(IUserService userService)
-    {
-        _userService = userService;
-    }
+    private readonly IUserService _userService = userService;
 
     [HttpGet("{publicId}")]
     public async Task<ActionResult<UserDTO>> GetUserByPublicId(Guid publicId)
@@ -22,6 +18,18 @@ public class UsersController : ControllerBase
         if (user == null)
         {
             return NotFound();
+        }
+
+        return Ok(user);
+    }
+
+    [HttpPost("login")]
+    public async Task<ActionResult<LoggedUserDTO>> Login([FromBody] Src.Application.DTOs.LoginRequest request)
+    {
+        var user = await _userService.LoginAsync(request.Email, request.Password);
+        if (user == null)
+        {
+            return Unauthorized("Invalid credentials");
         }
 
         return Ok(user);

--- a/src/WebApi/Program.cs
+++ b/src/WebApi/Program.cs
@@ -8,6 +8,8 @@ using UsersService.Src.Infraestructure.Repositories;
 
 var builder = WebApplication.CreateBuilder(args);
 
+DotNetEnv.Env.Load();
+
 // Add services to the container.
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddOpenApi();


### PR DESCRIPTION
### What I did
- Implemented all user-related operations (`login`, `get current user`, `refresh token`, `verify token`, `get by publicId`) using the **Command Pattern**.
- Refactored `UserService` to delegate to injected command classes.
- Registered all necessary Cognito and command dependencies in the DI container.
- Exposed the following endpoints:
  - `POST /api/users/login`
  - `GET /api/users/me`
  - `POST /api/users/refresh`
  - `GET /api/users/verify-token`
  - `GET /api/users/{publicId}`

### Why I did it
- To reduce the size and responsibility of `UserService`
- To improve modularity, testability, and separation of concerns
- To align with the same architectural approach used in other services like `Environments`

### How I did it
- Created command classes that implement `ICommand<TInput, TOutput>` for each user-related use case
- Registered Cognito clients and user pool with DI using values from `appsettings.json`
- Injected commands into `UserService` for full delegation
- Updated endpoints to use the refactored logic