### PR TITLE
Feature/spacio 28/log out

### DIFF
--- a/src/Application/Commands/Concretes/LogOutUserCommand.cs
+++ b/src/Application/Commands/Concretes/LogOutUserCommand.cs
@@ -1,0 +1,11 @@
+namespace UsersService.Src.Application.Commands.Concretes;
+
+using UsersService.Src.Application.Commands.Interfaces;
+
+public class LogoutUserCommand : ICommand<string?, bool>
+{
+    public Task<bool> ExecuteAsync(string? refreshToken)
+    {
+        return Task.FromResult(true);
+    }
+}

--- a/src/Application/Commands/Concretes/LogOutUserCommand.cs
+++ b/src/Application/Commands/Concretes/LogOutUserCommand.cs
@@ -1,11 +1,39 @@
 namespace UsersService.Src.Application.Commands.Concretes;
 
+using Amazon.CognitoIdentityProvider;
+using Amazon.CognitoIdentityProvider.Model;
 using UsersService.Src.Application.Commands.Interfaces;
 
-public class LogoutUserCommand : ICommand<string?, bool>
+public class LogoutUserCommand(
+    AmazonCognitoIdentityProviderClient provider,
+    string clientId) : ICommand<string?, bool>
 {
-    public Task<bool> ExecuteAsync(string? refreshToken)
+    private readonly AmazonCognitoIdentityProviderClient _provider = provider;
+    private readonly string _clientId = clientId;
+
+    public async Task<bool> ExecuteAsync(string? refreshToken)
     {
-        return Task.FromResult(true);
+        if (string.IsNullOrEmpty(refreshToken))
+        {
+            return false;
+        }
+
+        try
+        {
+            var request = new RevokeTokenRequest
+            {
+                Token = refreshToken,
+                ClientId = _clientId,
+            };
+
+            await _provider.RevokeTokenAsync(request);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            // Log the error
+            Console.WriteLine($"Error revoking token: {ex.Message}");
+            return false;
+        }
     }
 }

--- a/src/Application/Interfaces/IUserService.cs
+++ b/src/Application/Interfaces/IUserService.cs
@@ -14,4 +14,6 @@ public interface IUserService
     Task<string?> RefreshAccessTokenAsync(string refreshToken);
 
     Task<bool> IsAccessTokenValidAsync(string accessToken);
+
+    Task<bool> LogoutAsync(string? refreshToken);
 }

--- a/src/Application/Mapping/UserProfile.cs
+++ b/src/Application/Mapping/UserProfile.cs
@@ -10,14 +10,10 @@ public class UserProfile : Profile
     public UserProfile()
     {
         CreateMap<User, UserDTO>()
-            .ForMember(dest => dest.Role, opt => opt.MapFrom(src => src.Role.ToString()))
-            .ForMember(dest => dest.PhotoFileUrl, opt => opt.MapFrom(src =>
-                !string.IsNullOrEmpty(src.PhotoFileId) ? $"/media/{src.PhotoFileId}" : null));
+            .ForMember(dest => dest.Role, opt => opt.MapFrom(src => src.Role.ToString()));
 
         CreateMap<User, LoggedUserDTO>()
-            .ForMember(dest => dest.Role, opt => opt.MapFrom(src => src.Role.ToString()))
-            .ForMember(dest => dest.PhotoFileUrl, opt => opt.MapFrom(src =>
-                !string.IsNullOrEmpty(src.PhotoFileId) ? $"/media/{src.PhotoFileId}" : null));
+            .ForMember(dest => dest.Role, opt => opt.MapFrom(src => src.Role.ToString()));
 
         CreateMap<UserDTO, User>()
             .ForMember(dest => dest.Role, opt => opt.MapFrom(src => Enum.Parse<UserRole>(src.Role)));

--- a/src/Application/Services/UserService.cs
+++ b/src/Application/Services/UserService.cs
@@ -9,6 +9,7 @@ public class UserService(
     ICommand<string, LoggedUserDTO?> getLoggedUserCommand,
     ICommand<Guid, UserDTO?> getUserByPublicIdCommand,
     ICommand<string, string?> refreshTokenCommand,
+    ICommand<string?, bool> logoutUserCommand,
     ICommand<string, bool> validateAccessTokenCommand) : IUserService
 {
     private readonly ICommand<(string, string), LoggedUserDTO?> _loginUserCommand = loginUserCommand;
@@ -16,6 +17,8 @@ public class UserService(
     private readonly ICommand<Guid, UserDTO?> _getUserByPublicIdCommand = getUserByPublicIdCommand;
     private readonly ICommand<string, string?> _refreshTokenCommand = refreshTokenCommand;
     private readonly ICommand<string, bool> _validateAccessTokenCommand = validateAccessTokenCommand;
+
+    private readonly ICommand<string?, bool> _logoutUserCommand = logoutUserCommand;
 
     public Task<UserDTO?> GetByPublicIdAsync(Guid publicId) =>
         _getUserByPublicIdCommand.ExecuteAsync(publicId);
@@ -31,4 +34,7 @@ public class UserService(
 
     public Task<bool> IsAccessTokenValidAsync(string accessToken) =>
         _validateAccessTokenCommand.ExecuteAsync(accessToken);
+
+    public Task<bool> LogoutAsync(string? refreshToken) =>
+    _logoutUserCommand.ExecuteAsync(refreshToken);
 }

--- a/src/Domain/Entities/User.cs
+++ b/src/Domain/Entities/User.cs
@@ -4,7 +4,7 @@ namespace UsersService.Src.Domain.Entities;
 
 public class User
 {
-    public Guid Id { get; set; }
+    public Guid Id { get; set; } = Guid.NewGuid();
 
     public Guid PublicId { get; set; }
 

--- a/src/WebApi/Controllers/UserController.cs
+++ b/src/WebApi/Controllers/UserController.cs
@@ -105,4 +105,18 @@ public class UsersController(IUserService userService) : ControllerBase
         var isValid = await _userService.IsAccessTokenValidAsync(accessToken);
         return Ok(isValid);
     }
+
+    [HttpPost("logout")]
+    public async Task<IActionResult> Logout()
+    {
+        var refreshToken = Request.Cookies["refreshToken"];
+
+        await _userService.LogoutAsync(refreshToken);
+
+        Response.Cookies.Delete("accessToken");
+        Response.Cookies.Delete("refreshToken");
+        Response.Cookies.Delete("publicId");
+
+        return Ok(new { message = "Logged out successfully." });
+    }
 }

--- a/src/WebApi/Controllers/UserController.cs
+++ b/src/WebApi/Controllers/UserController.cs
@@ -1,8 +1,9 @@
-namespace UsersService.src.WebApi.Controllers;
-
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using UsersService.Src.Application.DTOs;
 using UsersService.Src.Application.Interfaces;
+
+namespace UsersService.src.WebApi.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
@@ -14,16 +15,11 @@ public class UsersController(IUserService userService) : ControllerBase
     public async Task<ActionResult<UserDTO>> GetUserByPublicId(Guid publicId)
     {
         var user = await _userService.GetByPublicIdAsync(publicId);
-        if (user == null)
-        {
-            return NotFound();
-        }
-
-        return Ok(user);
+        return user == null ? NotFound() : Ok(user);
     }
 
     [HttpPost("login")]
-    public async Task<ActionResult<LoggedUserDTO>> Login([FromBody] Src.Application.DTOs.LoginRequest request)
+    public async Task<ActionResult> Login([FromBody] LoginRequest request)
     {
         var user = await _userService.LoginAsync(request.Email, request.Password);
         if (user == null)
@@ -31,28 +27,81 @@ public class UsersController(IUserService userService) : ControllerBase
             return Unauthorized("Invalid credentials");
         }
 
+        Response.Cookies.Append("accessToken", user.AccessToken, new CookieOptions
+        {
+            HttpOnly = true,
+            Secure = true,
+            SameSite = SameSiteMode.Strict,
+            Expires = DateTime.UtcNow.AddDays(1),
+        });
+
+        Response.Cookies.Append("refreshToken", user.RefreshToken, new CookieOptions
+        {
+            HttpOnly = true,
+            Secure = true,
+            SameSite = SameSiteMode.Strict,
+            Expires = DateTime.UtcNow.AddDays(100),
+        });
+
+        Response.Cookies.Append("publicId", user.PublicId.ToString(), new CookieOptions
+        {
+            HttpOnly = true,
+            Secure = true,
+            SameSite = SameSiteMode.Strict,
+            Expires = DateTime.UtcNow.AddDays(100),
+        });
+
         return Ok(user);
     }
 
     [HttpGet("me")]
     public async Task<ActionResult<LoggedUserDTO>> GetCurrentUser()
     {
-        var accessToken = Request.Headers.Authorization.ToString().Replace("Bearer ", string.Empty);
+        var accessToken = Request.Cookies["accessToken"];
+        if (string.IsNullOrEmpty(accessToken))
+        {
+            return Unauthorized("No access token provided.");
+        }
+
         var user = await _userService.GetUserFromAccessTokenAsync(accessToken);
         return user == null ? Unauthorized() : Ok(user);
     }
 
     [HttpPost("refresh")]
-    public async Task<ActionResult<string>> RefreshAccessToken([FromBody] RefreshTokenRequest request)
+    public async Task<ActionResult> RefreshAccessToken()
     {
-        var newToken = await _userService.RefreshAccessTokenAsync(request.RefreshToken);
-        return string.IsNullOrEmpty(newToken) ? Unauthorized() : Ok(newToken);
+        var refreshToken = Request.Cookies["refreshToken"];
+        if (string.IsNullOrEmpty(refreshToken))
+        {
+            return Unauthorized("No refresh token provided.");
+        }
+
+        var newAccessToken = await _userService.RefreshAccessTokenAsync(refreshToken);
+        if (string.IsNullOrEmpty(newAccessToken))
+        {
+            return Unauthorized("Invalid refresh token.");
+        }
+
+        Response.Cookies.Append("accessToken", newAccessToken, new CookieOptions
+        {
+            HttpOnly = true,
+            Secure = true,
+            SameSite = SameSiteMode.Strict,
+            Expires = DateTime.UtcNow.AddDays(1),
+        });
+
+        return Ok(new { message = "Access token refreshed." });
     }
 
     [HttpGet("verify-token")]
     public async Task<ActionResult<bool>> VerifyAccessToken()
     {
-        var accessToken = Request.Headers.Authorization.ToString().Replace("Bearer ", string.Empty);
+        var accessToken = Request.Cookies["accessToken"];
+        if (string.IsNullOrEmpty(accessToken))
+        {
+            return Ok(false);
+        }
+
         var isValid = await _userService.IsAccessTokenValidAsync(accessToken);
         return Ok(isValid);
     }

--- a/src/WebApi/Program.cs
+++ b/src/WebApi/Program.cs
@@ -50,7 +50,15 @@ builder.Services.AddScoped<ICommand<string, LoggedUserDTO?>, GetLoggedUserComman
 builder.Services.AddScoped<ICommand<Guid, UserDTO?>, GetUserByPublicIdCommand>();
 builder.Services.AddScoped<ICommand<string, string?>, RefreshAccessTokenCommand>();
 builder.Services.AddScoped<ICommand<string, bool>, ValidateAccessTokenCommand>();
-builder.Services.AddScoped<ICommand<string?, bool>, LogoutUserCommand>();
+builder.Services.AddScoped<ICommand<string?, bool>, LogoutUserCommand>(provider =>
+{
+    var config = provider.GetRequiredService<IConfiguration>();
+    var cognitoClient = provider.GetRequiredService<AmazonCognitoIdentityProviderClient>();
+    var clientId = config["AWS:Cognito:ClientId"];
+    #pragma warning disable CS8604 // Possible null reference argument.
+    return new LogoutUserCommand(cognitoClient, clientId);
+    #pragma warning restore CS8604 // Possible null reference argument.
+});
 
 builder.Services.AddSingleton(provider =>
 {

--- a/src/WebApi/Program.cs
+++ b/src/WebApi/Program.cs
@@ -50,6 +50,7 @@ builder.Services.AddScoped<ICommand<string, LoggedUserDTO?>, GetLoggedUserComman
 builder.Services.AddScoped<ICommand<Guid, UserDTO?>, GetUserByPublicIdCommand>();
 builder.Services.AddScoped<ICommand<string, string?>, RefreshAccessTokenCommand>();
 builder.Services.AddScoped<ICommand<string, bool>, ValidateAccessTokenCommand>();
+builder.Services.AddScoped<ICommand<string?, bool>, LogoutUserCommand>();
 
 builder.Services.AddSingleton(provider =>
 {

--- a/src/WebApi/Program.cs
+++ b/src/WebApi/Program.cs
@@ -18,6 +18,26 @@ DotNetEnv.Env.Load();
 // Add services to the container.
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddOpenApi();
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("AllowAll", policy =>
+    {
+        policy.AllowAnyOrigin()
+              .AllowAnyMethod()
+              .AllowAnyHeader();
+    });
+});
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("AllowFrontEnd", policy =>
+    {
+        policy.WithOrigins("http://localhost:3000")
+              .AllowAnyMethod()
+              .AllowAnyHeader()
+              .AllowCredentials();
+    });
+});
+
 builder.Services.AddSwaggerGen();
 builder.Services.AddControllers();
 
@@ -48,20 +68,11 @@ builder.Services.AddSingleton(provider =>
         client);
 });
 
-builder.Services.AddCors(options =>
-{
-    options.AddPolicy("AllowAll", policy =>
-    {
-        policy.AllowAnyOrigin()
-              .AllowAnyMethod()
-              .AllowAnyHeader();
-    });
-});
-
 builder.Services.AddAutoMapper(typeof(UserProfile));
 
 var app = builder.Build();
 app.MapControllers();
+app.UseCors("AllowFrontEnd");
 
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())

--- a/src/WebApi/Program.cs
+++ b/src/WebApi/Program.cs
@@ -55,9 +55,9 @@ builder.Services.AddScoped<ICommand<string?, bool>, LogoutUserCommand>(provider 
     var config = provider.GetRequiredService<IConfiguration>();
     var cognitoClient = provider.GetRequiredService<AmazonCognitoIdentityProviderClient>();
     var clientId = config["AWS:Cognito:ClientId"];
-    #pragma warning disable CS8604 // Possible null reference argument.
+#pragma warning disable CS8604 // Possible null reference argument.
     return new LogoutUserCommand(cognitoClient, clientId);
-    #pragma warning restore CS8604 // Possible null reference argument.
+#pragma warning restore CS8604 // Possible null reference argument.
 });
 
 builder.Services.AddSingleton(provider =>


### PR DESCRIPTION
### What I did

Implemented the logout functionality for users in the UsersService.

---

### Why I did it

To allow users to securely end their session by deleting cookies and revoking the refresh token in Amazon Cognito, improving security and session control.

---

### How I did it

* Created a `LogoutUserCommand` that receives the `refreshToken` and revokes it via AWS Cognito using `RevokeTokenAsync`.
* Registered the command with a custom factory in `Program.cs` to inject the `clientId` from configuration.
* Added a new `LogoutAsync` method in `UserService` that delegates to the command.
* Implemented a `POST /api/Users/logout` endpoint in `UsersController` which:

  * Retrieves the `refreshToken` from cookies.
  * Calls the service to revoke the token.
  * Deletes all related cookies (`accessToken`, `refreshToken`, `publicId`).
