### PR TITLE
feature/SPACIO 107/become an owner

### DIFF
--- a/src/Application/DTOs/BankPaymentData/BankPaymentDataDto.cs
+++ b/src/Application/DTOs/BankPaymentData/BankPaymentDataDto.cs
@@ -1,0 +1,10 @@
+namespace UsersService.Src.Application.DTOs.BankPaymentData;
+
+public class BankPaymentDataDTO
+{
+    public string BankAccountNumber { get; set; } = string.Empty;
+
+    public string BankAccountHolder { get; set; } = string.Empty;
+
+    public string BankName { get; set; } = string.Empty;
+}

--- a/src/Application/DTOs/LoggedUserDTO.cs
+++ b/src/Application/DTOs/LoggedUserDTO.cs
@@ -1,3 +1,5 @@
+using UsersService.Src.Application.DTOs.BankPaymentData;
+
 namespace UsersService.Src.Application.DTOs;
 
 public class LoggedUserDTO
@@ -27,4 +29,6 @@ public class LoggedUserDTO
     public string AccessToken { get; set; } = string.Empty;
 
     public string RefreshToken { get; set; } = string.Empty;
+
+    public BankPaymentDataDTO? BankPaymentData { get; set; }
 }

--- a/src/Application/DTOs/PublicUserDTO.cs
+++ b/src/Application/DTOs/PublicUserDTO.cs
@@ -1,3 +1,5 @@
+using UsersService.Src.Application.DTOs.BankPaymentData;
+
 namespace UsersService.Src.Application.DTOs;
 
 public class UserDTO
@@ -19,4 +21,6 @@ public class UserDTO
     public string? PhotoFileUrl { get; set; }
 
     public bool? Verified { get; set; }
+
+    public BankPaymentDataDTO? BankPaymentData { get; set; }
 }

--- a/src/Application/Mapping/UserProfile.cs
+++ b/src/Application/Mapping/UserProfile.cs
@@ -2,6 +2,7 @@ namespace UsersService.Src.Application.Mapping;
 
 using AutoMapper;
 using UsersService.Src.Application.DTOs;
+using UsersService.Src.Application.DTOs.BankPaymentData;
 using UsersService.Src.Domain.Entities;
 using UsersService.Src.Domain.Enums;
 
@@ -20,5 +21,7 @@ public class UserProfile : Profile
 
         CreateMap<LoggedUserDTO, User>()
             .ForMember(dest => dest.Role, opt => opt.MapFrom(src => Enum.Parse<UserRole>(src.Role)));
+
+        CreateMap<BankPaymentData, BankPaymentDataDTO>();
     }
 }

--- a/src/Application/Services/BankPaymentDataService.cs
+++ b/src/Application/Services/BankPaymentDataService.cs
@@ -2,14 +2,18 @@ using UsersService.Src.Application.Commands.Data;
 using UsersService.Src.Application.Commands.Interfaces;
 using UsersService.Src.Application.DTOs.BankPaymentData;
 using UsersService.Src.Application.Interfaces;
+using UsersService.Src.Domain.Interfaces;
 
 namespace UsersService.Src.Application.Services;
 
 public class BankPaymentDataService(
     ICommand<BankPaymentInput, bool> createCommand,
-    ICommand<BankPaymentInput, bool> updateCommand)
+    ICommand<BankPaymentInput, bool> updateCommand,
+    IUserRepository userRepository)
     : IBankPaymentDataService
 {
+    private readonly IUserRepository _userRepository = userRepository;
+
     public async Task CreateAsync(CreateBankPaymentDataDto dto, Guid userPublicId)
     {
         var input = new BankPaymentInput
@@ -19,6 +23,8 @@ public class BankPaymentDataService(
         };
 
         await createCommand.ExecuteAsync(input);
+
+        await _userRepository.PromoteToOwnerAsync(userPublicId);
     }
 
     public async Task UpdateAsync(UpdateBankPaymentDataDto dto, Guid userPublicId)

--- a/src/Domain/Interfaces/IUserRepository.cs
+++ b/src/Domain/Interfaces/IUserRepository.cs
@@ -7,4 +7,6 @@ public interface IUserRepository
     Task<User?> GetByPublicIdAsync(Guid publicId);
 
     Task<User?> GetByIdAsync(Guid subId);
+
+    Task PromoteToOwnerAsync(Guid publicId);
 }


### PR DESCRIPTION
**What I did:**

* Updated the backend logic so that when a user creates their bank payment data, their role is automatically set to `Owner` if it isn’t already.

**Why I did it:**

* In the system, only Owners should be able to receive payments.
* A user who adds their bank account is effectively opting into becoming a provider/owner, so their role must reflect that.

**How I did it:**

* Added a new method `PromoteToOwnerAsync(Guid publicId)` in the `UserRepository`, which updates the user's role to `Owner` if needed.
* Called this method from `BankPaymentDataService.CreateAsync` after the bank data is created.
* Ensured all role update logic remains encapsulated inside the repository to follow clean architecture principles and promote reusability.
