### PR TITLE
Feature/spacio 40/change and reset password

### DIFF
--- a/src/Application/Commands/Concretes/ChangePasswordCommand.cs
+++ b/src/Application/Commands/Concretes/ChangePasswordCommand.cs
@@ -1,0 +1,33 @@
+using Amazon.CognitoIdentityProvider;
+using UsersService.Src.Application.Commands.Interfaces;
+
+namespace UsersService.Src.Application.Commands.Concretes;
+
+public class ChangePasswordCommand(
+    AmazonCognitoIdentityProviderClient provider
+) : ICommand<(string accessToken, DTOs.ChangePasswordRequest request), bool>
+{
+    private readonly AmazonCognitoIdentityProviderClient _provider = provider;
+
+    public async Task<bool> ExecuteAsync((string accessToken, DTOs.ChangePasswordRequest request) input)
+    {
+        var (accessToken, request) = input;
+
+        try
+        {
+            var changeRequest = new Amazon.CognitoIdentityProvider.Model.ChangePasswordRequest
+            {
+                AccessToken = accessToken,
+                PreviousPassword = request.CurrentPassword,
+                ProposedPassword = request.NewPassword,
+            };
+
+            var response = await _provider.ChangePasswordAsync(changeRequest);
+            return response.HttpStatusCode == System.Net.HttpStatusCode.OK;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/src/Application/Commands/Concretes/ConfirmForgotPasswordCommand.cs
+++ b/src/Application/Commands/Concretes/ConfirmForgotPasswordCommand.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Net;
+using Amazon.CognitoIdentityProvider;
+using UsersService.Src.Application.Commands.Interfaces;
+using UsersService.Src.Application.DTOs;
+
+namespace UsersService.src.Application.Commands.Concretes;
+
+public class ConfirmForgotPasswordCommand(
+    AmazonCognitoIdentityProviderClient provider,
+    IConfiguration config
+) : ICommand<ConfirmForgotPasswordRequest, bool>
+{
+    private readonly string _clientId = config["AWS:Cognito:ClientId"]!;
+
+    public async Task<bool> ExecuteAsync(ConfirmForgotPasswordRequest input)
+    {
+        try
+        {
+            var request = new Amazon.CognitoIdentityProvider.Model.ConfirmForgotPasswordRequest
+            {
+                ClientId = _clientId,
+                Username = input.Email,
+                ConfirmationCode = input.Code,
+                Password = input.NewPassword,
+            };
+
+            var response = await provider.ConfirmForgotPasswordAsync(request);
+            return response.HttpStatusCode == HttpStatusCode.OK;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/src/Application/Commands/Concretes/ForgotPasswordCommand.cs
+++ b/src/Application/Commands/Concretes/ForgotPasswordCommand.cs
@@ -1,0 +1,33 @@
+using System.Net;
+using Amazon.CognitoIdentityProvider;
+using UsersService.Src.Application.Commands.Interfaces;
+using UsersService.Src.Application.DTOs;
+
+namespace UsersService.Src.Application.Commands.Concretes;
+
+public class ForgotPasswordCommand(
+    AmazonCognitoIdentityProviderClient provider,
+    IConfiguration config
+) : ICommand<ForgotPasswordRequest, bool>
+{
+    private readonly string _clientId = config["AWS:Cognito:ClientId"]!;
+
+    public async Task<bool> ExecuteAsync(ForgotPasswordRequest req)
+    {
+        try
+        {
+            var request = new Amazon.CognitoIdentityProvider.Model.ForgotPasswordRequest
+            {
+                ClientId = _clientId,
+                Username = req.Email,
+            };
+
+            var response = await provider.ForgotPasswordAsync(request);
+            return response.HttpStatusCode == HttpStatusCode.OK;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/src/Application/Commands/Concretes/ResendConfirmationCommand.cs
+++ b/src/Application/Commands/Concretes/ResendConfirmationCommand.cs
@@ -1,25 +1,25 @@
 using Amazon.CognitoIdentityProvider;
 using Amazon.CognitoIdentityProvider.Model;
-using UsersService.src.Application.Commands.Interfaces;
 using UsersService.Src.Application.Commands.Interfaces;
+using UsersService.Src.Application.DTOs;
 
 namespace UsersService.Src.Application.Commands.Concretes;
 
 public class ResendConfirmationCodeCommand(
     AmazonCognitoIdentityProviderClient provider,
     IConfiguration configuration)
-    : IResendConfirmationCodeCommand
+    : ICommand<ResendCodeRequest, bool>
 {
     private readonly AmazonCognitoIdentityProviderClient _provider = provider;
     private readonly string _clientId = configuration["AWS:Cognito:ClientId"]!;
 
-    public async Task<bool> ExecuteAsync(string email)
+    public async Task<bool> ExecuteAsync(ResendCodeRequest req)
     {
         try
         {
             var request = new ResendConfirmationCodeRequest
             {
-                Username = email,
+                Username = req.Email,
                 ClientId = _clientId,
             };
 

--- a/src/Application/Commands/Concretes/ResendConfirmationCommand.cs
+++ b/src/Application/Commands/Concretes/ResendConfirmationCommand.cs
@@ -1,0 +1,34 @@
+using Amazon.CognitoIdentityProvider;
+using Amazon.CognitoIdentityProvider.Model;
+using UsersService.src.Application.Commands.Interfaces;
+using UsersService.Src.Application.Commands.Interfaces;
+
+namespace UsersService.Src.Application.Commands.Concretes;
+
+public class ResendConfirmationCodeCommand(
+    AmazonCognitoIdentityProviderClient provider,
+    IConfiguration configuration)
+    : IResendConfirmationCodeCommand
+{
+    private readonly AmazonCognitoIdentityProviderClient _provider = provider;
+    private readonly string _clientId = configuration["AWS:Cognito:ClientId"]!;
+
+    public async Task<bool> ExecuteAsync(string email)
+    {
+        try
+        {
+            var request = new ResendConfirmationCodeRequest
+            {
+                Username = email,
+                ClientId = _clientId,
+            };
+
+            var response = await _provider.ResendConfirmationCodeAsync(request);
+            return response.HttpStatusCode == System.Net.HttpStatusCode.OK;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/src/Application/Commands/Interfaces/IResendCodeConfirmationCommand.cs
+++ b/src/Application/Commands/Interfaces/IResendCodeConfirmationCommand.cs
@@ -1,6 +1,0 @@
-namespace UsersService.src.Application.Commands.Interfaces;
-
-public interface IResendConfirmationCodeCommand
-{
-    Task<bool> ExecuteAsync(string email);
-}

--- a/src/Application/Commands/Interfaces/IResendCodeConfirmationCommand.cs
+++ b/src/Application/Commands/Interfaces/IResendCodeConfirmationCommand.cs
@@ -1,0 +1,6 @@
+namespace UsersService.src.Application.Commands.Interfaces;
+
+public interface IResendConfirmationCodeCommand
+{
+    Task<bool> ExecuteAsync(string email);
+}

--- a/src/Application/DTOs/ChangePasswordRequest.cs
+++ b/src/Application/DTOs/ChangePasswordRequest.cs
@@ -1,0 +1,8 @@
+namespace UsersService.Src.Application.DTOs;
+
+public class ChangePasswordRequest
+{
+    public string CurrentPassword { get; set; } = default!;
+
+    public string NewPassword { get; set; } = default!;
+}

--- a/src/Application/DTOs/ConfirmForgotPasswordRequest.cs
+++ b/src/Application/DTOs/ConfirmForgotPasswordRequest.cs
@@ -1,0 +1,10 @@
+namespace UsersService.Src.Application.DTOs;
+
+public class ConfirmForgotPasswordRequest
+{
+    public string Email { get; set; } = default!;
+
+    public string Code { get; set; } = default!;
+
+    public string NewPassword { get; set; } = default!;
+}

--- a/src/Application/DTOs/ForgotPasswordRequest.cs
+++ b/src/Application/DTOs/ForgotPasswordRequest.cs
@@ -1,0 +1,6 @@
+namespace UsersService.Src.Application.DTOs;
+
+public class ForgotPasswordRequest
+{
+    public string Email { get; set; } = default!;
+}

--- a/src/Application/DTOs/ResendCodeRequest.cs
+++ b/src/Application/DTOs/ResendCodeRequest.cs
@@ -1,0 +1,6 @@
+namespace UsersService.Src.Application.DTOs;
+
+public class ResendCodeRequest
+{
+    public string Email { get; set; } = string.Empty;
+}

--- a/src/Application/Interfaces/IUserService.cs
+++ b/src/Application/Interfaces/IUserService.cs
@@ -23,7 +23,11 @@ public interface IUserService
 
     Task<bool> ConfirmSignUpAsync(ConfirmSignUpRequest request);
 
-    Task<bool> ResendConfirmationCodeAsync(string email);
+    Task<bool> ResendConfirmationCodeAsync(ResendCodeRequest email);
 
     Task<bool> ChangePasswordAsync(string accessToken, ChangePasswordRequest request);
+
+    Task<bool> StartPasswordResetAsync(ForgotPasswordRequest request);
+
+    Task<bool> ConfirmPasswordResetAsync(ConfirmForgotPasswordRequest request);
 }

--- a/src/Application/Interfaces/IUserService.cs
+++ b/src/Application/Interfaces/IUserService.cs
@@ -23,4 +23,6 @@ public interface IUserService
     Task<bool> SignUpAsync(SignUpRequest request);
 
     Task<bool> ConfirmSignUpAsync(ConfirmSignUpRequest request);
+
+    Task<bool> ResendConfirmationCodeAsync(string email);
 }

--- a/src/Application/Interfaces/IUserService.cs
+++ b/src/Application/Interfaces/IUserService.cs
@@ -1,4 +1,3 @@
-using UsersService.src;
 using UsersService.Src.Application.DTOs;
 using UsersService.Src.Application.DTOs.Update;
 
@@ -25,4 +24,6 @@ public interface IUserService
     Task<bool> ConfirmSignUpAsync(ConfirmSignUpRequest request);
 
     Task<bool> ResendConfirmationCodeAsync(string email);
+
+    Task<bool> ChangePasswordAsync(string accessToken, ChangePasswordRequest request);
 }

--- a/src/Application/Services/UserService.cs
+++ b/src/Application/Services/UserService.cs
@@ -1,3 +1,4 @@
+using UsersService.src.Application.Commands.Interfaces;
 using UsersService.Src.Application.Commands.Interfaces;
 using UsersService.Src.Application.DTOs;
 using UsersService.Src.Application.DTOs.Update;
@@ -14,7 +15,8 @@ public class UserService(
     ICommand<string, bool> validateAccessTokenCommand,
     ICommand<(Guid, UpdateUserRequestDTO), bool> updateUserCommand,
     ICommand<SignUpRequest, bool> signUpUserCommand,
-    ICommand<ConfirmSignUpRequest, bool> confirmSignUpUserCommand) : IUserService
+    ICommand<ConfirmSignUpRequest, bool> confirmSignUpUserCommand,
+    IResendConfirmationCodeCommand resendConfirmationCodeCommand) : IUserService
 {
     private readonly ICommand<(string, string), LoggedUserDTO?> _loginUserCommand = loginUserCommand;
     private readonly ICommand<string, LoggedUserDTO?> _getLoggedUserCommand = getLoggedUserCommand;
@@ -25,6 +27,7 @@ public class UserService(
     private readonly ICommand<(Guid, UpdateUserRequestDTO), bool> _updateUserCommand = updateUserCommand;
     private readonly ICommand<SignUpRequest, bool> _signUpUserCommand = signUpUserCommand;
     private readonly ICommand<ConfirmSignUpRequest, bool> _confirmSignUpUserCommand = confirmSignUpUserCommand;
+    private readonly IResendConfirmationCodeCommand _resendConfirmationCodeCommand = resendConfirmationCodeCommand;
 
     public Task<bool> SignUpAsync(SignUpRequest request) =>
         _signUpUserCommand.ExecuteAsync(request);
@@ -52,4 +55,7 @@ public class UserService(
 
     public Task<bool> ConfirmSignUpAsync(ConfirmSignUpRequest request) =>
         _confirmSignUpUserCommand.ExecuteAsync(request);
+
+    public Task<bool> ResendConfirmationCodeAsync(string email) =>
+        _resendConfirmationCodeCommand.ExecuteAsync(email);
 }

--- a/src/Application/Services/UserService.cs
+++ b/src/Application/Services/UserService.cs
@@ -1,4 +1,3 @@
-using UsersService.src.Application.Commands.Interfaces;
 using UsersService.Src.Application.Commands.Interfaces;
 using UsersService.Src.Application.DTOs;
 using UsersService.Src.Application.DTOs.Update;
@@ -16,8 +15,10 @@ public class UserService(
     ICommand<(Guid, UpdateUserRequestDTO), bool> updateUserCommand,
     ICommand<SignUpRequest, bool> signUpUserCommand,
     ICommand<ConfirmSignUpRequest, bool> confirmSignUpUserCommand,
-    IResendConfirmationCodeCommand resendConfirmationCodeCommand,
-    ICommand<(string, ChangePasswordRequest), bool> changePasswordCommand
+    ICommand<ResendCodeRequest, bool> resendConfirmationCodeCommand,
+    ICommand<(string, ChangePasswordRequest), bool> changePasswordCommand,
+    ICommand<ForgotPasswordRequest, bool> forgotPasswordCommand,
+    ICommand<ConfirmForgotPasswordRequest, bool> confirmForgotPasswordCommand
 ) : IUserService
 {
     private readonly ICommand<(string, string), LoggedUserDTO?> _loginUserCommand = loginUserCommand;
@@ -29,9 +30,10 @@ public class UserService(
     private readonly ICommand<(Guid, UpdateUserRequestDTO), bool> _updateUserCommand = updateUserCommand;
     private readonly ICommand<SignUpRequest, bool> _signUpUserCommand = signUpUserCommand;
     private readonly ICommand<ConfirmSignUpRequest, bool> _confirmSignUpUserCommand = confirmSignUpUserCommand;
-    private readonly IResendConfirmationCodeCommand _resendConfirmationCodeCommand = resendConfirmationCodeCommand;
-
+    private readonly ICommand<ResendCodeRequest, bool> _resendConfirmationCodeCommand = resendConfirmationCodeCommand;
     private readonly ICommand<(string, ChangePasswordRequest), bool> _changePasswordCommand = changePasswordCommand;
+    private readonly ICommand<ForgotPasswordRequest, bool> _forgotPasswordCommand = forgotPasswordCommand;
+    private readonly ICommand<ConfirmForgotPasswordRequest, bool> _confirmForgotPasswordCommand = confirmForgotPasswordCommand;
 
     public Task<bool> SignUpAsync(SignUpRequest request) =>
         _signUpUserCommand.ExecuteAsync(request);
@@ -60,9 +62,15 @@ public class UserService(
     public Task<bool> ConfirmSignUpAsync(ConfirmSignUpRequest request) =>
         _confirmSignUpUserCommand.ExecuteAsync(request);
 
-    public Task<bool> ResendConfirmationCodeAsync(string email) =>
-        _resendConfirmationCodeCommand.ExecuteAsync(email);
+    public Task<bool> ResendConfirmationCodeAsync(ResendCodeRequest request) =>
+        _resendConfirmationCodeCommand.ExecuteAsync(request);
 
     public Task<bool> ChangePasswordAsync(string accessToken, ChangePasswordRequest request) =>
         _changePasswordCommand.ExecuteAsync((accessToken, request));
+
+    public Task<bool> StartPasswordResetAsync(ForgotPasswordRequest request) =>
+    _forgotPasswordCommand.ExecuteAsync(request);
+
+    public Task<bool> ConfirmPasswordResetAsync(ConfirmForgotPasswordRequest request) =>
+        _confirmForgotPasswordCommand.ExecuteAsync(request);
 }

--- a/src/Application/Services/UserService.cs
+++ b/src/Application/Services/UserService.cs
@@ -16,7 +16,9 @@ public class UserService(
     ICommand<(Guid, UpdateUserRequestDTO), bool> updateUserCommand,
     ICommand<SignUpRequest, bool> signUpUserCommand,
     ICommand<ConfirmSignUpRequest, bool> confirmSignUpUserCommand,
-    IResendConfirmationCodeCommand resendConfirmationCodeCommand) : IUserService
+    IResendConfirmationCodeCommand resendConfirmationCodeCommand,
+    ICommand<(string, ChangePasswordRequest), bool> changePasswordCommand
+) : IUserService
 {
     private readonly ICommand<(string, string), LoggedUserDTO?> _loginUserCommand = loginUserCommand;
     private readonly ICommand<string, LoggedUserDTO?> _getLoggedUserCommand = getLoggedUserCommand;
@@ -28,6 +30,8 @@ public class UserService(
     private readonly ICommand<SignUpRequest, bool> _signUpUserCommand = signUpUserCommand;
     private readonly ICommand<ConfirmSignUpRequest, bool> _confirmSignUpUserCommand = confirmSignUpUserCommand;
     private readonly IResendConfirmationCodeCommand _resendConfirmationCodeCommand = resendConfirmationCodeCommand;
+
+    private readonly ICommand<(string, ChangePasswordRequest), bool> _changePasswordCommand = changePasswordCommand;
 
     public Task<bool> SignUpAsync(SignUpRequest request) =>
         _signUpUserCommand.ExecuteAsync(request);
@@ -58,4 +62,7 @@ public class UserService(
 
     public Task<bool> ResendConfirmationCodeAsync(string email) =>
         _resendConfirmationCodeCommand.ExecuteAsync(email);
+
+    public Task<bool> ChangePasswordAsync(string accessToken, ChangePasswordRequest request) =>
+        _changePasswordCommand.ExecuteAsync((accessToken, request));
 }

--- a/src/WebApi/Controllers/UserController.cs
+++ b/src/WebApi/Controllers/UserController.cs
@@ -219,7 +219,7 @@ public class UsersController(IUserService userService) : ControllerBase
     [HttpPost("resend-code")]
     public async Task<IActionResult> ResendConfirmationCode([FromBody] ResendCodeRequest request)
     {
-        var result = await _userService.ResendConfirmationCodeAsync(request.Email);
+        var result = await _userService.ResendConfirmationCodeAsync(request);
 
         if (result)
         {
@@ -243,5 +243,23 @@ public class UsersController(IUserService userService) : ControllerBase
         return result
             ? Ok(new { message = "Password changed successfully." })
             : BadRequest("Failed to change password. Please verify your current password.");
+    }
+
+    [HttpPost("forgot-password")]
+    public async Task<IActionResult> ForgotPassword([FromBody] Src.Application.DTOs.ForgotPasswordRequest request)
+    {
+        var result = await _userService.StartPasswordResetAsync(request);
+        return result
+            ? Ok(new { message = "Password reset code sent." })
+            : BadRequest("Failed to send reset code.");
+    }
+
+    [HttpPost("confirm-forgot-password")]
+    public async Task<IActionResult> ConfirmForgotPassword([FromBody] Src.Application.DTOs.ConfirmForgotPasswordRequest request)
+    {
+        var result = await _userService.ConfirmPasswordResetAsync(request);
+        return result
+            ? Ok(new { message = "Password updated successfully." })
+            : BadRequest("Failed to reset password. Check code or try again.");
     }
 }

--- a/src/WebApi/Controllers/UserController.cs
+++ b/src/WebApi/Controllers/UserController.cs
@@ -228,4 +228,20 @@ public class UsersController(IUserService userService) : ControllerBase
 
         return BadRequest("Failed to resend confirmation code.");
     }
+
+    [HttpPost("change-password")]
+    public async Task<IActionResult> ChangePassword([FromBody] Src.Application.DTOs.ChangePasswordRequest request)
+    {
+        var accessToken = Request.Cookies["accessToken"];
+        if (string.IsNullOrEmpty(accessToken))
+        {
+            return Unauthorized("Access token missing.");
+        }
+
+        var result = await _userService.ChangePasswordAsync(accessToken, request);
+
+        return result
+            ? Ok(new { message = "Password changed successfully." })
+            : BadRequest("Failed to change password. Please verify your current password.");
+    }
 }

--- a/src/WebApi/Controllers/UserController.cs
+++ b/src/WebApi/Controllers/UserController.cs
@@ -215,4 +215,17 @@ public class UsersController(IUserService userService) : ControllerBase
             return StatusCode(500, $"Internal server error: {ex.Message}");
         }
     }
+
+    [HttpPost("resend-code")]
+    public async Task<IActionResult> ResendConfirmationCode([FromBody] ResendCodeRequest request)
+    {
+        var result = await _userService.ResendConfirmationCodeAsync(request.Email);
+
+        if (result)
+        {
+            return Ok(new { message = "Confirmation code resent successfully." });
+        }
+
+        return BadRequest("Failed to resend confirmation code.");
+    }
 }

--- a/src/WebApi/Program.cs
+++ b/src/WebApi/Program.cs
@@ -60,6 +60,10 @@ builder.Services.AddScoped<ICommand<string, string?>, RefreshAccessTokenCommand>
 builder.Services.AddScoped<ICommand<string, bool>, ValidateAccessTokenCommand>();
 builder.Services.AddScoped<ICommand<SignUpRequest, bool>, SignUpUserCommand>();
 builder.Services.AddScoped<ICommand<ConfirmSignUpRequest, bool>, ConfirmSignUpCommand>();
+builder.Services.AddScoped<ICommand<ResendCodeRequest, bool>, ResendConfirmationCodeCommand>();
+builder.Services.AddScoped<ICommand<(string, ChangePasswordRequest), bool>, ChangePasswordCommand>();
+builder.Services.AddScoped<ICommand<ForgotPasswordRequest, bool>, ForgotPasswordCommand>();
+builder.Services.AddScoped<ICommand<ConfirmForgotPasswordRequest, bool>, ConfirmForgotPasswordCommand>();
 builder.Services.AddScoped<ICommand<string?, bool>, LogoutUserCommand>(provider =>
 {
     var config = provider.GetRequiredService<IConfiguration>();


### PR DESCRIPTION
**What I did:**
Implemented the restore password functionality, including sending and resending a reset code, and confirming the new password with that code.

**Why I did it:**
Users need a way to recover access to their accounts in case they forget their passwords. Amazon Cognito provides a built-in flow for this, requiring a reset code and new password confirmation.

**How I did it:**

* Created two commands using the existing `ICommand` pattern: one for initiating the password reset (sending or resending the code), and another for confirming the password reset using the code.
* Added two DTOs: `ForgotPasswordRequest` and `ConfirmForgotPasswordRequest`.
* Extended the `UserService` to expose the new commands through `StartPasswordResetAsync` and `ConfirmPasswordResetAsync`.
* Added two endpoints in `UsersController`: `/forgot-password` and `/confirm-forgot-password`.
* Used Cognito's `ForgotPasswordAsync` and `ConfirmForgotPasswordAsync` methods to handle the full reset flow.